### PR TITLE
FLOW-895: Added persistence to database load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,9 @@ com_crashlytics_export_strings.xml
 
 # Maven Shade
 dependency-reduced-pom.xml
+
+### VSCode ###
+.vscode/
+.classpath
+.project
+.settings

--- a/src/main/java/com/manywho/services/dummy/dummy/Dummy.java
+++ b/src/main/java/com/manywho/services/dummy/dummy/Dummy.java
@@ -26,6 +26,10 @@ public class Dummy implements Type {
         return id;
     }
 
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/com/manywho/services/dummy/dummy/DummyDatabase.java
+++ b/src/main/java/com/manywho/services/dummy/dummy/DummyDatabase.java
@@ -3,6 +3,7 @@ package com.manywho.services.dummy.dummy;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 import com.manywho.sdk.api.draw.content.Command;
 import com.manywho.sdk.api.run.elements.type.ListFilter;
@@ -28,19 +29,24 @@ public class DummyDatabase implements Database<ApplicationConfiguration, Dummy> 
 
     @Override
     public List<Dummy> findAll(ApplicationConfiguration configuration, ObjectDataType objectDataType, Command command, ListFilter filter, List<MObject> objects) {
-        return new ArrayList<Dummy>(DUMMIES.values());
+        ArrayList<Dummy> dummies = new ArrayList<Dummy>(DUMMIES.values());
+        return dummies;
     }
 
     @Override
     public Dummy create(ApplicationConfiguration applicationConfiguration, ObjectDataType objectDataType, Dummy dummy) {
+        dummy.setId(UUID.randomUUID().toString());
         DUMMIES.put(dummy.getId(), dummy);
+        
         return dummy;
     }
 
     @Override
     public List<Dummy> create(ApplicationConfiguration applicationConfiguration, ObjectDataType objectDataType, List<Dummy> list) {
+        list.forEach(dummy -> {
+            dummy.setId(UUID.randomUUID().toString());
+            DUMMIES.put(dummy.getId(), dummy);});
         
-        list.forEach(d -> DUMMIES.put(d.getId(), d));
         return new ArrayList<Dummy>(DUMMIES.values());
     }
 
@@ -57,6 +63,7 @@ public class DummyDatabase implements Database<ApplicationConfiguration, Dummy> 
     @Override
     public Dummy update(ApplicationConfiguration applicationConfiguration, ObjectDataType objectDataType, Dummy dummy) {
         DUMMIES.put(dummy.getId(), dummy);
+        
         return dummy;
     }
 

--- a/src/main/java/com/manywho/services/dummy/dummy/DummyDatabase.java
+++ b/src/main/java/com/manywho/services/dummy/dummy/DummyDatabase.java
@@ -1,6 +1,9 @@
 package com.manywho.services.dummy.dummy;
 
-import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 import com.manywho.sdk.api.draw.content.Command;
 import com.manywho.sdk.api.run.elements.type.ListFilter;
 import com.manywho.sdk.api.run.elements.type.MObject;
@@ -8,33 +11,37 @@ import com.manywho.sdk.api.run.elements.type.ObjectDataType;
 import com.manywho.sdk.services.database.Database;
 import com.manywho.services.dummy.ApplicationConfiguration;
 
-import java.util.List;
-
 public class DummyDatabase implements Database<ApplicationConfiguration, Dummy> {
+    
+    private static final HashMap<String, Dummy> DUMMIES = new HashMap<String, Dummy>();
+    
+    static
+    {
+        DUMMIES.put("123", new Dummy("123", "Jonjo", 23));
+        DUMMIES.put("345", new Dummy("345", "Dom", 39));
+    }
+
     @Override
-    public Dummy find(ApplicationConfiguration configuration, ObjectDataType objectDataType, Command command, String id) {
-        return new Dummy("123", "Jonjo", 23);
+    public Dummy find(ApplicationConfiguration configuration, ObjectDataType objectDataType, Command command, String id) {   
+        return DUMMIES.get(id);
     }
 
     @Override
     public List<Dummy> findAll(ApplicationConfiguration configuration, ObjectDataType objectDataType, Command command, ListFilter filter, List<MObject> objects) {
-        return Lists.newArrayList(
-                new Dummy("123", "Jonjo", 23),
-                new Dummy("456", "Jonjo", 23)
-        );
+        return new ArrayList<Dummy>(DUMMIES.values());
     }
 
     @Override
     public Dummy create(ApplicationConfiguration applicationConfiguration, ObjectDataType objectDataType, Dummy dummy) {
-        return null;
+        DUMMIES.put(dummy.getId(), dummy);
+        return dummy;
     }
 
     @Override
     public List<Dummy> create(ApplicationConfiguration applicationConfiguration, ObjectDataType objectDataType, List<Dummy> list) {
-        return Lists.newArrayList(
-                new Dummy("123", "Jonjo", 23),
-                new Dummy("456", "Jonjo", 23)
-        );
+        
+        list.forEach(d -> DUMMIES.put(d.getId(), d));
+        return new ArrayList<Dummy>(DUMMIES.values());
     }
 
     @Override
@@ -49,7 +56,8 @@ public class DummyDatabase implements Database<ApplicationConfiguration, Dummy> 
 
     @Override
     public Dummy update(ApplicationConfiguration applicationConfiguration, ObjectDataType objectDataType, Dummy dummy) {
-        return null;
+        DUMMIES.put(dummy.getId(), dummy);
+        return dummy;
     }
 
     @Override


### PR DESCRIPTION
This essentially just adds an in-memory collection for the objects returned by the database load action so they can persist for E2E test purposes.